### PR TITLE
pin hugo version

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: 'latest'
+          hugo-version: '0.155.3'
           # extended: true
 
       - name: Build


### PR DESCRIPTION
The papermod theme breaks with the latest hugo version (0.156).